### PR TITLE
Add some detail that the image might be on the Wikidata item

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,16 +1,16 @@
 {
-    "commtech-commons-speedy-header": "{{PLURAL:$1|A Commons file|Commons files}} used on this page {{PLURAL:$1|has|have}} been nominated for speedy deletion",
-    "commtech-commons-speedy-body-start": "The following Wikimedia Commons {{PLURAL:$1|file|files}} used on this page {{PLURAL:$1|has|have}} been nominated for speedy deletion:",
+    "commtech-commons-speedy-header": "{{PLURAL:$1|A Commons file|Commons files}} used on this page or {{PLURAL:$1|its|their}} Wikidata {{PLURAL:$1|item|items}} {{PLURAL:$1|has|have}} been nominated for speedy deletion",
+    "commtech-commons-speedy-body-start": "The following Wikimedia Commons {{PLURAL:$1|file|files}} used on this page or {{PLURAL:$1|its|their}} Wikidata {{PLURAL:$1|item|items}} {{PLURAL:$1|has|have}} been nominated for speedy deletion:",
     "commtech-commons-speedy-body-end": "You can see the {{PLURAL:$1|reason|reasons}} for deletion at the file description {{PLURAL:$1|page|pages}} linked above.",
     "commtech-commons-speedy-summary": "Files used on this page are up for speedy deletion",
-    "commtech-commons-discussion-header": "{{PLURAL:$1|A Commons file|Commons files}} used on this page {{PLURAL:$1|has|have}} been nominated for deletion",
-    "commtech-commons-discussion-body-start": "The following Wikimedia Commons {{PLURAL:$1|file|files}} used on this page {{PLURAL:$1|has|have}} been nominated for deletion:",
+    "commtech-commons-discussion-header": "{{PLURAL:$1|A Commons file|Commons files}} used on this page or {{PLURAL:$1|its|their}} Wikidata {{PLURAL:$1|item|items}} {{PLURAL:$1|has|have}} been nominated for deletion",
+    "commtech-commons-discussion-body-start": "The following Wikimedia Commons {{PLURAL:$1|file|files}} used on this page or {{PLURAL:$1|its|their}} Wikidata {{PLURAL:$1|item|items}} {{PLURAL:$1|has|have}} been nominated for deletion:",
     "commtech-commons-discussion-body-end-matching": "Participate in the deletion discussion at the [[$1|nomination page]].",
     "commtech-commons-discussion-body-end-mismatching": "Participate in the deletion {{PLURAL:$1|discussions}} at the nomination {{PLURAL:$1|pages}} linked above.",
-    "commtech-commons-discussion-summary": "Files used on this page are up for deletion",
+    "commtech-commons-discussion-summary": "Files used on this page or its Wikidata item are up for deletion",
     "commtech-commons-discussion-line": "[[$1]] ([[$2|discussion]])",
-    "commtech-commons-nopermission-header": "{{PLURAL:$1|A Commons file|Commons files}} used on this page {{PLURAL:$1|is|are}} missing permission",
-    "commtech-commons-nopermission-body-start": "The following Wikimedia Commons {{PLURAL:$1|file|files}} used on this page {{PLURAL:$1|is|are}} missing permission information and may be deleted:",
+    "commtech-commons-nopermission-header": "{{PLURAL:$1|A Commons file|Commons files}} used on this page or {{PLURAL:$1|its|their}} Wikidata {{PLURAL:$1|item|items}} {{PLURAL:$1|is|are}} missing permission",
+    "commtech-commons-nopermission-body-start": "The following Wikimedia Commons {{PLURAL:$1|file|files}} used on this page or {{PLURAL:$1|its|their}} Wikidata {{PLURAL:$1|item|items}} {{PLURAL:$1|is|are}} missing permission information and may be deleted:",
     "commtech-commons-nopermission-body-end": "You can see the details at the file description {{PLURAL:$1|page|pages}} linked above.",
-    "commtech-commons-nopermission-summary": "Files used on this page are missing permission"
+    "commtech-commons-nopermission-summary": "Files used on this page or its Wikidata item are missing permission"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,16 +1,16 @@
 {
-    "commtech-commons-speedy-header": "{{PLURAL:$1|A Commons file|Commons files}} used on this page or {{PLURAL:$1|its|their}} Wikidata {{PLURAL:$1|item|items}} {{PLURAL:$1|has|have}} been nominated for speedy deletion",
-    "commtech-commons-speedy-body-start": "The following Wikimedia Commons {{PLURAL:$1|file|files}} used on this page or {{PLURAL:$1|its|their}} Wikidata {{PLURAL:$1|item|items}} {{PLURAL:$1|has|have}} been nominated for speedy deletion:",
+    "commtech-commons-speedy-header": "{{PLURAL:$1|A Commons file|Commons files}} used on this page or its Wikidata item {{PLURAL:$1|has|have}} been nominated for speedy deletion",
+    "commtech-commons-speedy-body-start": "The following Wikimedia Commons {{PLURAL:$1|file|files}} used on this page or its Wikidata item {{PLURAL:$1|has|have}} been nominated for speedy deletion:",
     "commtech-commons-speedy-body-end": "You can see the {{PLURAL:$1|reason|reasons}} for deletion at the file description {{PLURAL:$1|page|pages}} linked above.",
     "commtech-commons-speedy-summary": "Files used on this page are up for speedy deletion",
-    "commtech-commons-discussion-header": "{{PLURAL:$1|A Commons file|Commons files}} used on this page or {{PLURAL:$1|its|their}} Wikidata {{PLURAL:$1|item|items}} {{PLURAL:$1|has|have}} been nominated for deletion",
-    "commtech-commons-discussion-body-start": "The following Wikimedia Commons {{PLURAL:$1|file|files}} used on this page or {{PLURAL:$1|its|their}} Wikidata {{PLURAL:$1|item|items}} {{PLURAL:$1|has|have}} been nominated for deletion:",
+    "commtech-commons-discussion-header": "{{PLURAL:$1|A Commons file|Commons files}} used on this page or its Wikidata item {{PLURAL:$1|has|have}} been nominated for deletion",
+    "commtech-commons-discussion-body-start": "The following Wikimedia Commons {{PLURAL:$1|file|files}} used on this page or its Wikidata item {{PLURAL:$1|has|have}} been nominated for deletion:",
     "commtech-commons-discussion-body-end-matching": "Participate in the deletion discussion at the [[$1|nomination page]].",
     "commtech-commons-discussion-body-end-mismatching": "Participate in the deletion {{PLURAL:$1|discussions}} at the nomination {{PLURAL:$1|pages}} linked above.",
     "commtech-commons-discussion-summary": "Files used on this page or its Wikidata item are up for deletion",
     "commtech-commons-discussion-line": "[[$1]] ([[$2|discussion]])",
-    "commtech-commons-nopermission-header": "{{PLURAL:$1|A Commons file|Commons files}} used on this page or {{PLURAL:$1|its|their}} Wikidata {{PLURAL:$1|item|items}} {{PLURAL:$1|is|are}} missing permission",
-    "commtech-commons-nopermission-body-start": "The following Wikimedia Commons {{PLURAL:$1|file|files}} used on this page or {{PLURAL:$1|its|their}} Wikidata {{PLURAL:$1|item|items}} {{PLURAL:$1|is|are}} missing permission information and may be deleted:",
+    "commtech-commons-nopermission-header": "{{PLURAL:$1|A Commons file|Commons files}} used on this page or its Wikidata item {{PLURAL:$1|is|are}} missing permission",
+    "commtech-commons-nopermission-body-start": "The following Wikimedia Commons {{PLURAL:$1|file|files}} used on this page or its Wikidata item {{PLURAL:$1|is|are}} missing permission information and may be deleted:",
     "commtech-commons-nopermission-body-end": "You can see the details at the file description {{PLURAL:$1|page|pages}} linked above.",
     "commtech-commons-nopermission-summary": "Files used on this page or its Wikidata item are missing permission"
 }

--- a/test/test_formatters.py
+++ b/test/test_formatters.py
@@ -22,8 +22,8 @@ class TestFormatters(unittest.TestCase):
 
         expected = """
 
-== {{subst:PLURAL:2|A Commons file|Commons files}} used on this page or {{subst:PLURAL:2|its|their}} Wikidata {{subst:PLURAL:2|item|items}} {{subst:PLURAL:2|has|have}} been nominated for deletion ==
-The following Wikimedia Commons {{subst:PLURAL:2|file|files}} used on this page or {{subst:PLURAL:2|its|their}} Wikidata {{subst:PLURAL:2|item|items}} {{subst:PLURAL:2|has|have}} been nominated for deletion:
+== {{subst:PLURAL:2|A Commons file|Commons files}} used on this page or its Wikidata item {{subst:PLURAL:2|has|have}} been nominated for deletion ==
+The following Wikimedia Commons {{subst:PLURAL:2|file|files}} used on this page or its Wikidata item {{subst:PLURAL:2|has|have}} been nominated for deletion:
 * [[commons:File:File1.jpg|File1.jpg]] ([[commons:Commons:Deletion requests/File1.jpg|discussion]])<!-- COMMONSBOT: discussion | 2018-05-15T13:30:00+00:00 | File1.jpg -->
 * [[commons:File:File2.jpg|File2.jpg]] ([[commons:Commons:Deletion requests/File2.jpg|discussion]])<!-- COMMONSBOT: discussion | 2018-05-15T13:30:00+00:00 | File2.jpg -->
 Participate in the deletion {{subst:PLURAL:2|discussions}} at the nomination {{subst:PLURAL:2|pages}} linked above. —~~~~
@@ -34,8 +34,8 @@ Participate in the deletion {{subst:PLURAL:2|discussions}} at the nomination {{s
         states[1].discussion_page = states[0].discussion_page
         expected = """
 
-== {{subst:PLURAL:2|A Commons file|Commons files}} used on this page or {{subst:PLURAL:2|its|their}} Wikidata {{subst:PLURAL:2|item|items}} {{subst:PLURAL:2|has|have}} been nominated for deletion ==
-The following Wikimedia Commons {{subst:PLURAL:2|file|files}} used on this page or {{subst:PLURAL:2|its|their}} Wikidata {{subst:PLURAL:2|item|items}} {{subst:PLURAL:2|has|have}} been nominated for deletion:
+== {{subst:PLURAL:2|A Commons file|Commons files}} used on this page or its Wikidata item {{subst:PLURAL:2|has|have}} been nominated for deletion ==
+The following Wikimedia Commons {{subst:PLURAL:2|file|files}} used on this page or its Wikidata item {{subst:PLURAL:2|has|have}} been nominated for deletion:
 * [[commons:File:File1.jpg|File1.jpg]]<!-- COMMONSBOT: discussion | 2018-05-15T13:30:00+00:00 | File1.jpg -->
 * [[commons:File:File2.jpg|File2.jpg]]<!-- COMMONSBOT: discussion | 2018-05-15T13:30:00+00:00 | File2.jpg -->
 Participate in the deletion discussion at the [[commons:Commons:Deletion requests/File1.jpg|nomination page]]. —~~~~
@@ -45,8 +45,8 @@ Participate in the deletion discussion at the [[commons:Commons:Deletion request
 
         expected = """
 
-== {{subst:PLURAL:1|A Commons file|Commons files}} used on this page or {{subst:PLURAL:1|its|their}} Wikidata {{subst:PLURAL:1|item|items}} {{subst:PLURAL:1|has|have}} been nominated for deletion ==
-The following Wikimedia Commons {{subst:PLURAL:1|file|files}} used on this page or {{subst:PLURAL:1|its|their}} Wikidata {{subst:PLURAL:1|item|items}} {{subst:PLURAL:1|has|have}} been nominated for deletion:
+== {{subst:PLURAL:1|A Commons file|Commons files}} used on this page or its Wikidata item {{subst:PLURAL:1|has|have}} been nominated for deletion ==
+The following Wikimedia Commons {{subst:PLURAL:1|file|files}} used on this page or its Wikidata item {{subst:PLURAL:1|has|have}} been nominated for deletion:
 * [[commons:File:File1.jpg|File1.jpg]]<!-- COMMONSBOT: discussion | 2018-05-15T13:30:00+00:00 | File1.jpg -->
 Participate in the deletion discussion at the [[commons:Commons:Deletion requests/File1.jpg|nomination page]]. —~~~~
 """  # noqa
@@ -62,8 +62,8 @@ Participate in the deletion discussion at the [[commons:Commons:Deletion request
 
         expected = """
 
-== {{subst:PLURAL:2|A Commons file|Commons files}} used on this page or {{subst:PLURAL:2|its|their}} Wikidata {{subst:PLURAL:2|item|items}} {{subst:PLURAL:2|has|have}} been nominated for speedy deletion ==
-The following Wikimedia Commons {{subst:PLURAL:2|file|files}} used on this page or {{subst:PLURAL:2|its|their}} Wikidata {{subst:PLURAL:2|item|items}} {{subst:PLURAL:2|has|have}} been nominated for speedy deletion:
+== {{subst:PLURAL:2|A Commons file|Commons files}} used on this page or its Wikidata item {{subst:PLURAL:2|has|have}} been nominated for speedy deletion ==
+The following Wikimedia Commons {{subst:PLURAL:2|file|files}} used on this page or its Wikidata item {{subst:PLURAL:2|has|have}} been nominated for speedy deletion:
 * [[commons:File:File1.jpg|File1.jpg]]<!-- COMMONSBOT: speedy | 2018-05-15T13:30:00+00:00 | File1.jpg -->
 * [[commons:File:File2.jpg|File2.jpg]]<!-- COMMONSBOT: speedy | 2018-05-15T13:30:00+00:00 | File2.jpg -->
 You can see the {{subst:PLURAL:2|reason|reasons}} for deletion at the file description {{subst:PLURAL:2|page|pages}} linked above. —~~~~

--- a/test/test_formatters.py
+++ b/test/test_formatters.py
@@ -22,8 +22,8 @@ class TestFormatters(unittest.TestCase):
 
         expected = """
 
-== {{subst:PLURAL:2|A Commons file|Commons files}} used on this page {{subst:PLURAL:2|has|have}} been nominated for deletion ==
-The following Wikimedia Commons {{subst:PLURAL:2|file|files}} used on this page {{subst:PLURAL:2|has|have}} been nominated for deletion:
+== {{subst:PLURAL:2|A Commons file|Commons files}} used on this page or {{subst:PLURAL:2|its|their}} Wikidata {{subst:PLURAL:2|item|items}} {{subst:PLURAL:2|has|have}} been nominated for deletion ==
+The following Wikimedia Commons {{subst:PLURAL:2|file|files}} used on this page or {{subst:PLURAL:2|its|their}} Wikidata {{subst:PLURAL:2|item|items}} {{subst:PLURAL:2|has|have}} been nominated for deletion:
 * [[commons:File:File1.jpg|File1.jpg]] ([[commons:Commons:Deletion requests/File1.jpg|discussion]])<!-- COMMONSBOT: discussion | 2018-05-15T13:30:00+00:00 | File1.jpg -->
 * [[commons:File:File2.jpg|File2.jpg]] ([[commons:Commons:Deletion requests/File2.jpg|discussion]])<!-- COMMONSBOT: discussion | 2018-05-15T13:30:00+00:00 | File2.jpg -->
 Participate in the deletion {{subst:PLURAL:2|discussions}} at the nomination {{subst:PLURAL:2|pages}} linked above. —~~~~
@@ -34,8 +34,8 @@ Participate in the deletion {{subst:PLURAL:2|discussions}} at the nomination {{s
         states[1].discussion_page = states[0].discussion_page
         expected = """
 
-== {{subst:PLURAL:2|A Commons file|Commons files}} used on this page {{subst:PLURAL:2|has|have}} been nominated for deletion ==
-The following Wikimedia Commons {{subst:PLURAL:2|file|files}} used on this page {{subst:PLURAL:2|has|have}} been nominated for deletion:
+== {{subst:PLURAL:2|A Commons file|Commons files}} used on this page or {{subst:PLURAL:2|its|their}} Wikidata {{subst:PLURAL:2|item|items}} {{subst:PLURAL:2|has|have}} been nominated for deletion ==
+The following Wikimedia Commons {{subst:PLURAL:2|file|files}} used on this page or {{subst:PLURAL:2|its|their}} Wikidata {{subst:PLURAL:2|item|items}} {{subst:PLURAL:2|has|have}} been nominated for deletion:
 * [[commons:File:File1.jpg|File1.jpg]]<!-- COMMONSBOT: discussion | 2018-05-15T13:30:00+00:00 | File1.jpg -->
 * [[commons:File:File2.jpg|File2.jpg]]<!-- COMMONSBOT: discussion | 2018-05-15T13:30:00+00:00 | File2.jpg -->
 Participate in the deletion discussion at the [[commons:Commons:Deletion requests/File1.jpg|nomination page]]. —~~~~
@@ -45,8 +45,8 @@ Participate in the deletion discussion at the [[commons:Commons:Deletion request
 
         expected = """
 
-== {{subst:PLURAL:1|A Commons file|Commons files}} used on this page {{subst:PLURAL:1|has|have}} been nominated for deletion ==
-The following Wikimedia Commons {{subst:PLURAL:1|file|files}} used on this page {{subst:PLURAL:1|has|have}} been nominated for deletion:
+== {{subst:PLURAL:1|A Commons file|Commons files}} used on this page or {{subst:PLURAL:1|its|their}} Wikidata {{subst:PLURAL:1|item|items}} {{subst:PLURAL:1|has|have}} been nominated for deletion ==
+The following Wikimedia Commons {{subst:PLURAL:1|file|files}} used on this page or {{subst:PLURAL:1|its|their}} Wikidata {{subst:PLURAL:1|item|items}} {{subst:PLURAL:1|has|have}} been nominated for deletion:
 * [[commons:File:File1.jpg|File1.jpg]]<!-- COMMONSBOT: discussion | 2018-05-15T13:30:00+00:00 | File1.jpg -->
 Participate in the deletion discussion at the [[commons:Commons:Deletion requests/File1.jpg|nomination page]]. —~~~~
 """  # noqa
@@ -62,8 +62,8 @@ Participate in the deletion discussion at the [[commons:Commons:Deletion request
 
         expected = """
 
-== {{subst:PLURAL:2|A Commons file|Commons files}} used on this page {{subst:PLURAL:2|has|have}} been nominated for speedy deletion ==
-The following Wikimedia Commons {{subst:PLURAL:2|file|files}} used on this page {{subst:PLURAL:2|has|have}} been nominated for speedy deletion:
+== {{subst:PLURAL:2|A Commons file|Commons files}} used on this page or {{subst:PLURAL:2|its|their}} Wikidata {{subst:PLURAL:2|item|items}} {{subst:PLURAL:2|has|have}} been nominated for speedy deletion ==
+The following Wikimedia Commons {{subst:PLURAL:2|file|files}} used on this page or {{subst:PLURAL:2|its|their}} Wikidata {{subst:PLURAL:2|item|items}} {{subst:PLURAL:2|has|have}} been nominated for speedy deletion:
 * [[commons:File:File1.jpg|File1.jpg]]<!-- COMMONSBOT: speedy | 2018-05-15T13:30:00+00:00 | File1.jpg -->
 * [[commons:File:File2.jpg|File2.jpg]]<!-- COMMONSBOT: speedy | 2018-05-15T13:30:00+00:00 | File2.jpg -->
 You can see the {{subst:PLURAL:2|reason|reasons}} for deletion at the file description {{subst:PLURAL:2|page|pages}} linked above. —~~~~


### PR DESCRIPTION
There was some confusion from users when an image marked by the bot is used on the page's Wikidata item but not in the page. Adding a bit of text to cover that eventuality.