### PR TITLE
post_notifs.py: skip files that are missing

### DIFF
--- a/commonsbot/state.py
+++ b/commonsbot/state.py
@@ -58,7 +58,7 @@ class DeletionState(object):
 
     def load_discussion_info(self, site):
         """
-        Loads deletion discussion page information int othis object's discussion_page property
+        Loads deletion discussion page information into this object's discussion_page property
         """
         if self.info_loaded or self.type != 'discussion':
             return
@@ -68,7 +68,8 @@ class DeletionState(object):
             page = pywikibot.Page(site, 'File:' + self.file_name)
         else:
             page = self.discussion_page
-        text = page.get(get_redirect=True)
+
+        text = page.text
 
         discussion = get_nomination_page(text)
         if discussion is None:

--- a/post-notifs.py
+++ b/post-notifs.py
@@ -61,7 +61,7 @@ def spam_notifications(notif_type, formatter_class, talk_page, files):
 
     try:
         text = talk_page.get()
-    except pywikibot.exceptions.NoPage:
+    except pywikibot.exceptions.NoPageError:
         text = ''
 
     ourlist = []
@@ -127,6 +127,11 @@ def process_list(type, formatter_class):
 
     for filename in lines:
         file = FilePage(commons, filename)
+
+        if not file.exists():
+            print('File:%s missing, skipping.' % filename, file=sys.stderr)
+            continue
+
         if filename in file_states:
             state = file_states[filename]
         else:


### PR DESCRIPTION
Newer versions of Pywikibot will throw an exception if you attempt to
fetch content of nonexistent pages.

Bug: T298567