### PR TITLE
make-list: Only open a ToolsDB connection when it's being used

### DIFF
--- a/make-list.py
+++ b/make-list.py
@@ -8,8 +8,6 @@ from pywikibot.site import Namespace
 from pprint import pprint
 
 commons = Site('commons', 'commons')
-userdb = mysql.connect()
-store = DeletionStateStore(userdb)
 
 
 def load_files(categories, depth):
@@ -50,7 +48,11 @@ def make_list(type, categories, depth, delay):
     files = load_files(categories, depth)
     print('%s pages found for %s deletion' % (len(files), type))
 
-    states = store.refresh_state(files, type)
+    userdb = mysql.connect()
+    with userdb:
+        store = DeletionStateStore(userdb)
+        states = store.refresh_state(files, type)
+
     file = open('lists/%s.txt' % type, 'w', encoding='utf8')
     count = 0
     for state in states:


### PR DESCRIPTION
Instead of opening a single database connection at the start of the
script and then relying that it's still alive after querying MediaWiki
for the affected pages, open the database connection only when starting
to update the database and then nicely close it afterwards (and then
re-open a new one when updating the next category). This should both
avoid holding open unnecessary connections (to comply with the ToolsDB
connection handling policy), and solve the timeouts seen on T339145.

Bug: T339145
